### PR TITLE
Fix SPM installation

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -32,5 +32,11 @@ let package = Package(
         "FBLFunctional",
       ]
     ),
+  ],
+  products: [
+    .library(
+      name: "FBLFunctional",
+      targets: ["FBLFunctional"]
+    )
   ]
 )

--- a/Package.swift
+++ b/Package.swift
@@ -22,6 +22,12 @@ import PackageDescription
 
 let package = Package(
   name: "FBLFunctional",
+  products: [
+    .library(
+      name: "FBLFunctional",
+      targets: ["FBLFunctional"]
+    )
+  ],
   targets: [
     .target(
       name: "FBLFunctional"
@@ -32,11 +38,5 @@ let package = Package(
         "FBLFunctional",
       ]
     ),
-  ],
-  products: [
-    .library(
-      name: "FBLFunctional",
-      targets: ["FBLFunctional"]
-    )
   ]
 )


### PR DESCRIPTION
Original `Package.swift` is missing products property. This leads to `package 'FBLFunctional' contains no products` error in Xcode. I updated `Package.swift` file and included missing property. This allows FBLFunctional to be properly integrated in any Xcode project using SPM.

Another user has already created an issue [here](https://github.com/google/functional-objc/issues/9)